### PR TITLE
Fix Label Assigned to RichTextLabel Error

### DIFF
--- a/addons/sv_mod_loader/interface/mod_load_error_window/mod_load_error_window.gd
+++ b/addons/sv_mod_loader/interface/mod_load_error_window/mod_load_error_window.gd
@@ -18,7 +18,7 @@ signal skip
 		_update_error()
 
 
-@onready var _error_message_label: RichTextLabel = get_node(
+@onready var _error_message_label: Label = get_node(
 	"PanelContainer/MarginContainer/VBoxContainer/ErrorMessageLabel")
 
 


### PR DESCRIPTION
Fixes an error that would crash the mod loader immediately.